### PR TITLE
Enable network by default for Fedora JeOS

### DIFF
--- a/fedora/x86_64/fedora-25.0-JeOS/config.sh
+++ b/fedora/x86_64/fedora-25.0-JeOS/config.sh
@@ -18,7 +18,7 @@ baseMount
 #======================================
 # Activate services
 #--------------------------------------
-#...
+baseInsertService network
 
 #======================================
 # Setup default target, multi-user

--- a/fedora/x86_64/fedora-25.0-JeOS/config.xml
+++ b/fedora/x86_64/fedora-25.0-JeOS/config.xml
@@ -34,6 +34,7 @@
         <package name="plymouth-theme-charge"/>
         <package name="grub2-starfield-theme"/>
         <package name="selinux-policy-targeted"/>
+        <package name="dhclient"/>
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>

--- a/fedora/x86_64/fedora-25.0-JeOS/root/etc/sysconfig/network-scripts/ifcfg-lan0
+++ b/fedora/x86_64/fedora-25.0-JeOS/root/etc/sysconfig/network-scripts/ifcfg-lan0
@@ -1,3 +1,3 @@
-DEVICE=eth0
+DEVICE=lan0
 BOOTPROTO=dhcp
 ONBOOT=yes


### PR DESCRIPTION
This commit enables network service by default, includes dhclient
to make sure it is possible to get dhcp addresses and also corrects
network device name in network-scripts.