### PR TITLE
Adding explicit kernel package

### DIFF
--- a/suse/x86_64/suse-SLE12-community-JeOS/config.xml
+++ b/suse/x86_64/suse-SLE12-community-JeOS/config.xml
@@ -192,13 +192,20 @@
         <package name="xen" arch="x86_64" replaces=""/>
         <package name="gfxboot-branding-SLE" bootinclude="true" bootdelete="true"/>
     </packages>
-    <packages type="image" profiles="vmxFlavour">
+    <packages type="image" profiles="vmxFlavour,vagrant">
         <package name="kernel-default" replaces="kernel-xen"/>
         <package name="kernel-default" replaces="xen-kmp-default"/>
         <package name="kernel-default" replaces="xen-libs"/>
         <package name="kernel-default" replaces="xen-tools"/>
         <package name="kernel-default" replaces="xen"/>
         <package name="gfxboot-branding-SLE" bootinclude="true" bootdelete="true"/>
+    </packages>
+    <packages type="image" profiles="netboot">
+        <package name="kernel-default" replaces="kernel-xen"/>
+        <package name="kernel-default" replaces="xen-kmp-default"/>
+        <package name="kernel-default" replaces="xen-libs"/>
+        <package name="kernel-default" replaces="xen-tools"/>
+        <package name="kernel-default" replaces="xen"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>

--- a/ubuntu/x86_64/ubuntu-xenial-JeOS/config.xml
+++ b/ubuntu/x86_64/ubuntu-xenial-JeOS/config.xml
@@ -53,6 +53,7 @@
         <package name="plymouth"/>
         <package name="grub-efi-amd64"/>
         <package name="dracut"/>
+        <package name="linux-generic"/>
     </packages>
     <packages type="bootstrap">
         <package name="initramfs-tools"/>


### PR DESCRIPTION
This commit adds the default kernel package, this is needed with
the current KIWI version to makes sure the boot code uses the
appropriate kernel package. The build fails due to a runtime check
if the kernel is not explicit.