### PR TITLE
Including a base image docker example for Leap 42.2

### DIFF
--- a/suse/x86_64/suse-leap-42.2-docker/config.sh
+++ b/suse/x86_64/suse-leap-42.2-docker/config.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2013 SUSE LLC
+#               :
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for SUSE based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+suseConfig
+
+#======================================
+# Import repositories' keys
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
+# Disable recommends
+#--------------------------------------
+sed -i 's/.*installRecommends.*/installRecommends = no/g' /etc/zypp/zypper.conf
+
+#======================================
+# Remove locale files
+#--------------------------------------
+(cd /usr/share/locale && find -name '*.mo' | xargs rm)
+
+
+exit 0

--- a/suse/x86_64/suse-leap-42.2-docker/config.xml
+++ b/suse/x86_64/suse-leap-42.2-docker/config.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.5" name="Docker-Leap-42.2">
+  <description type="system">
+    <author>David Cassany</author>
+    <contact>dcassany@suse.de</contact>
+    <specification>openSUSE 42.2 Docker container</specification>
+  </description>
+  <preferences>
+    <type image="docker">
+      <containerconfig
+        name="opensuse"
+        tag="42.2"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"/>
+    </type>
+    <version>1.0.0</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-check-signatures>false</rpm-check-signatures>
+    <rpm-force>true</rpm-force>
+    <rpm-excludedocs>true</rpm-excludedocs>
+    <locale>en_US</locale>
+    <keytable>us.map.gz</keytable>
+    <hwclock>utc</hwclock>
+  </preferences>
+  <users>
+    <user home="/root" name="root" groups="root"/>
+  </users>
+  <repository type="rpm-md" alias="Main Update" imageinclude="true">
+    <source path="obs://openSUSE:Leap:42.2:Update/standard"/>
+  </repository>
+  <repository type="rpm-md" alias="Main" imageinclude="true">
+    <source path="obs://openSUSE:Leap:42.2/standard"/>
+  </repository>
+  <packages type="image">
+    <package name="ca-certificates"/>
+    <package name="ca-certificates-mozilla"/>
+    <package name="coreutils"/>
+    <package name="iputils"/>
+    <package name="openSUSE-build-key"/>
+  </packages>
+  <packages type="bootstrap">
+    <package name="filesystem"/>
+    <package name="openSUSE-release"/>
+    <package name="glibc-locale"/>
+  </packages>
+  <packages type="delete">
+    <package name="aaa_base"/>
+    <package name="dbus-1"/>
+    <package name="dracut"/>
+    <package name="fipscheck"/>
+    <package name="glibc-locale"/>
+    <package name="kbd"/>
+    <package name="kmod"/>
+    <package name="ncurses-utils"/>
+    <package name="pinentry"/>
+    <package name="pkg-config"/>
+    <package name="sg3_utils"/>
+    <package name="systemd-sysvinit"/>
+    <package name="udev"/>
+  </packages>
+</image>


### PR DESCRIPTION
This commit includes an appliance example specific for a Docker
container base image.