### PR TITLE
Add Debian-based JeOS images v2

### DIFF
--- a/debian/x86_64/debian-jessie-JeOS/config.sh
+++ b/debian/x86_64/debian-jessie-JeOS/config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for Debian based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Mount system filesystems
+#--------------------------------------
+baseMount
+
+#======================================
+# Activate services
+#--------------------------------------
+baseInsertService sshd
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Umount kernel filesystems
+#--------------------------------------
+baseCleanMount
+
+exit 0

--- a/debian/x86_64/debian-jessie-JeOS/config.xml
+++ b/debian/x86_64/debian-jessie-JeOS/config.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.7" name="LimeJeOS-Debian-Jessie">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>Debian Jessie JeOS</specification>
+    </description>
+    <preferences>
+        <version>8.9</version>
+        <packagemanager>apt-get</packagemanager>
+        <!-- FIXME: Themes do not work for some reason -->
+        <bootsplash-theme>fade-in</bootsplash-theme>
+        <bootloader-theme>starfield</bootloader-theme>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+        <type image="vmx" primary="true" filesystem="ext4" bootloader="grub2" firmware="efi"/>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+<!-- NOTE: the order of the repositories matters in case of apt. The first
+     package found matching the solver criteria will be used. Thus if the
+     latest package should be selected it is important that the
+     repository providing it is added first in the list, e.g the
+     update repository
+-->
+    <repository type="apt-deb" distribution="jessie" components="main contrib non-free">
+        <source path="http://ftp.halifax.rwth-aachen.de/debian"/>
+    </repository>
+    <repository type="apt-deb">
+      <source path="obs://Virtualization:Appliances:CommonBoot/Debian_8.0"/>
+    </repository>
+    <packages type="image">
+        <package name="grub-theme-starfield"/>
+        <package name="plymouth-themes" bootinclude="true"/>
+        <package name="vim"/>
+        <package name="plymouth"/>
+        <package name="grub-efi-amd64"/>
+        <package name="dracut"/>
+        <package name="xz-utils"/>
+        <package name="binutils"/>
+        <package name="linux-image-amd64"/>
+        <package name="isolinux"/>
+        <package name="syslinux"/>
+        <package name="syslinux-common"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="initramfs-tools"/>
+        <package name="linux-image-amd64"/>
+        <package name="grub2"/>
+    </packages>
+</image>

--- a/debian/x86_64/debian-jessie-JeOS/root/etc/network/interfaces.d/lan0
+++ b/debian/x86_64/debian-jessie-JeOS/root/etc/network/interfaces.d/lan0
@@ -1,0 +1,2 @@
+auto lan0
+iface lan0 inet dhcp

--- a/debian/x86_64/debian-jessie-JeOS/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/debian/x86_64/debian-jessie-JeOS/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"

--- a/debian/x86_64/debian-stretch-JeOS/config.sh
+++ b/debian/x86_64/debian-stretch-JeOS/config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for Debian based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Mount system filesystems
+#--------------------------------------
+baseMount
+
+#======================================
+# Activate services
+#--------------------------------------
+baseInsertService sshd
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Umount kernel filesystems
+#--------------------------------------
+baseCleanMount
+
+exit 0

--- a/debian/x86_64/debian-stretch-JeOS/config.xml
+++ b/debian/x86_64/debian-stretch-JeOS/config.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.7" name="LimeJeOS-Debian-Stretch">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>Debian Stretch JeOS</specification>
+    </description>
+    <preferences>
+        <version>9.2</version>
+        <packagemanager>apt-get</packagemanager>
+        <!-- FIXME: Themes do not work for some reason -->
+        <bootsplash-theme>fade-in</bootsplash-theme>
+        <bootloader-theme>starfield</bootloader-theme>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+        <type image="vmx" primary="true" filesystem="ext4" bootloader="grub2" firmware="efi"/>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+<!-- NOTE: the order of the repositories matters in case of apt. The first
+     package found matching the solver criteria will be used. Thus if the
+     latest package should be selected it is important that the
+     repository providing it is added first in the list, e.g the
+     update repository
+-->
+    <repository type="apt-deb" distribution="stretch" components="main contrib non-free">
+        <source path="http://ftp.halifax.rwth-aachen.de/debian"/>
+    </repository>
+    <repository type="apt-deb">
+      <source path="obs://Virtualization:Appliances:CommonBoot/Debian_9.0"/>
+    </repository>
+    <packages type="image">
+        <package name="grub-theme-starfield"/>
+        <package name="plymouth-themes" bootinclude="true"/>
+        <package name="vim"/>
+        <package name="plymouth"/>
+        <package name="grub-efi-amd64"/>
+        <package name="dracut"/>
+        <package name="xz-utils"/>
+        <package name="binutils"/>
+        <package name="linux-image-amd64"/>
+        <package name="isolinux"/>
+        <package name="syslinux"/>
+        <package name="syslinux-common"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="initramfs-tools"/>
+        <package name="linux-image-amd64"/>
+        <package name="grub2"/>
+    </packages>
+</image>

--- a/debian/x86_64/debian-stretch-JeOS/root/etc/network/interfaces.d/lan0
+++ b/debian/x86_64/debian-stretch-JeOS/root/etc/network/interfaces.d/lan0
@@ -1,0 +1,2 @@
+auto lan0
+iface lan0 inet dhcp

--- a/debian/x86_64/debian-stretch-JeOS/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/debian/x86_64/debian-stretch-JeOS/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"

--- a/ubuntu/x86_64/ubuntu-xenial-JeOS/root/etc/network/interfaces.d/lan0
+++ b/ubuntu/x86_64/ubuntu-xenial-JeOS/root/etc/network/interfaces.d/lan0
@@ -1,0 +1,2 @@
+auto lan0
+iface lan0 inet dhcp


### PR DESCRIPTION
Changes in v2:
 - Removed iso and oem build types for now
 - Actually build the Stretch image from Stretch packages