### PR TITLE
Adding timezone package

### DIFF
--- a/suse/x86_64/suse-leap-42.2-JeOS/config.xml
+++ b/suse/x86_64/suse-leap-42.2-JeOS/config.xml
@@ -70,6 +70,7 @@
         <package name="which"/>
         <package name="shim"/>
         <package name="kernel-default"/>
+        <package name="timezone"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE"/>

--- a/suse/x86_64/suse-leap-42.3-JeOS/config.xml
+++ b/suse/x86_64/suse-leap-42.3-JeOS/config.xml
@@ -72,6 +72,7 @@
         <package name="which"/>
         <package name="shim"/>
         <package name="kernel-default"/>
+        <package name="timezone"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE"/>

--- a/suse/x86_64/suse-tumbleweed-JeOS/config.xml
+++ b/suse/x86_64/suse-tumbleweed-JeOS/config.xml
@@ -54,6 +54,7 @@
         <package name="dhcp-client"/>
         <package name="which"/>
         <package name="kernel-default"/>
+        <package name="timezone"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE"/>


### PR DESCRIPTION
With the latest update on how kiwi handles the locales with
systemd-firstboot, only locales defined in timezone package can be
set, thus Europe/Berlin is not possible if timezone is not installed.