### PR TITLE
Debian: List some Priority: important packages explicitly

### DIFF
--- a/debian/x86_64/debian-jessie-JeOS/config.xml
+++ b/debian/x86_64/debian-jessie-JeOS/config.xml
@@ -38,6 +38,15 @@
         <package name="isolinux"/>
         <package name="syslinux"/>
         <package name="syslinux-common"/>
+        <package name="init"/>
+        <package name="gnupg"/>
+        <package name="iproute2"/>
+        <package name="iptables"/>
+        <package name="iputils-ping"/>
+        <package name="ifupdown"/>
+        <package name="isc-dhcp-client"/>
+        <package name="netbase"/>
+        <package name="bsdmainutils"/>
     </packages>
     <packages type="bootstrap">
         <package name="initramfs-tools"/>

--- a/debian/x86_64/debian-stretch-JeOS/config.xml
+++ b/debian/x86_64/debian-stretch-JeOS/config.xml
@@ -38,6 +38,15 @@
         <package name="isolinux"/>
         <package name="syslinux"/>
         <package name="syslinux-common"/>
+        <package name="init"/>
+        <package name="gnupg"/>
+        <package name="iproute2"/>
+        <package name="iptables"/>
+        <package name="iputils-ping"/>
+        <package name="ifupdown"/>
+        <package name="isc-dhcp-client"/>
+        <package name="netbase"/>
+        <package name="bsdmainutils"/>
     </packages>
     <packages type="bootstrap">
         <package name="initramfs-tools"/>


### PR DESCRIPTION
A patch to kiwi will run debootstrap with --variant=minbase, which means
that only packages with Priority: required will be autoselected.