### PR TITLE
Replace genisoimage with mkisofs usage

### DIFF
--- a/custom_boot/arch/arm/oemboot/suse-SLES15/config.xml
+++ b/custom_boot/arch/arm/oemboot/suse-SLES15/config.xml
@@ -101,7 +101,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="hwinfo"/>

--- a/custom_boot/arch/arm/oemboot/suse-leap15.0/config.xml
+++ b/custom_boot/arch/arm/oemboot/suse-leap15.0/config.xml
@@ -101,7 +101,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="hwinfo"/>

--- a/custom_boot/arch/arm/oemboot/suse-tumbleweed/config.xml
+++ b/custom_boot/arch/arm/oemboot/suse-tumbleweed/config.xml
@@ -104,7 +104,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="hwinfo"/>

--- a/custom_boot/arch/ppc/oemboot/suse-SLES15/config.xml
+++ b/custom_boot/arch/ppc/oemboot/suse-SLES15/config.xml
@@ -100,7 +100,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="hwinfo"/>

--- a/custom_boot/arch/s390/oemboot/suse-SLES15/config.xml
+++ b/custom_boot/arch/s390/oemboot/suse-SLES15/config.xml
@@ -102,7 +102,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/custom_boot/arch/s390/oemboot/suse-tumbleweed/config.xml
+++ b/custom_boot/arch/s390/oemboot/suse-tumbleweed/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/custom_boot/arch/x86_64/oemboot/suse-SLES15/config.xml
+++ b/custom_boot/arch/x86_64/oemboot/suse-SLES15/config.xml
@@ -122,7 +122,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/custom_boot/arch/x86_64/oemboot/suse-leap15.0/config.xml
+++ b/custom_boot/arch/x86_64/oemboot/suse-leap15.0/config.xml
@@ -124,7 +124,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/custom_boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/custom_boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -130,7 +130,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -151,7 +151,11 @@ Summary:        KIWI - buildservice host requirements for iso images
 Group:          System/Management
 Provides:       kiwi-image:iso
 Requires:       dosfstools
+%if 0%{suse_version} >= 1500
+Requires:       mkisofs
+%else
 Requires:       genisoimage
+%endif
 %description -n kiwi-image-iso-requires
 Meta package for the buildservice to pull in all required packages
 for the build host to build live iso images


### PR DESCRIPTION
Replace genisoimage (wodim) with mkisofs (cdrtools) for
Tumbleweed, Leap 15 and SLES15 sample image configurations.

These are additional changes in preparation to actually remove wodim.
