### PR TITLE
Add syslinux as a requirement for iso images builds

### DIFF
--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -158,6 +158,7 @@ Requires:       mkisofs
 %else
 Requires:       genisoimage
 %endif
+Requires:       syslinux
 %description -n kiwi-image-iso-requires
 Meta package for the buildservice to pull in all required packages
 for the build host to build live iso images


### PR DESCRIPTION
This commit adds a syslinux requirement for kiwi-image-iso-requires
package. This way the build service environment is certain to include
syslinux into the build env for ISO builds.

Fixes bsc#1103398