### PR TITLE
Add syslinux requirement to kiwi-oem-image-requires

### DIFF
--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -169,6 +169,7 @@ Group:          System/Management
 Provides:       kiwi-image:oem
 Requires:       kiwi-filesystem-requires
 Requires:       jing
+Requires:       syslinux
 %description -n kiwi-image-oem-requires
 Meta package for the buildservice to pull in all required packages
 for the build host to build oem disk images


### PR DESCRIPTION
This commit makes sure that syslinux is also required for OEM images
in OBS. This is needed when the image includes installiso="true".

Fixes bsc#1103398