### PR TITLE
Fixup console multiplexer

### DIFF
--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -120,11 +120,10 @@ function hideSplash {
     # hook called at the end of this function
     # ----
     local IFS=$IFS_ORIG
-    test -e /proc/splash && echo verbose > /proc/splash
     if lookup plymouthd &>/dev/null;then
-        plymouth hide-splash
-        # reset tty after plymouth messed with it
-        consoleInit
+        if [ "$(activeConsoles)" -lt "2" ]; then
+            plymouth hide-splash
+        fi
     fi
     runHook handleSplash "$@"
 }
@@ -7357,7 +7356,6 @@ function Dialog {
     local dialog_code=/tmp/dialog_code
     hideSplash
     cat > $dialog_call <<- EOF
-		reset
 		dialog \
 			--ok-label "$TEXT_OK" \
 			--cancel-label "$TEXT_CANCEL" \


### PR DESCRIPTION
In case multiple consoles are configured plymouth usually
multiplexes the output to all open consoles. This is true
until kiwi calls the dialog program to run interactive
dialogs. Interaction requires keyboard input which is
occupied by plymouth on the master console. Therefore the
custom kiwi boot code calls the hide-splash command which
tells plymouth to release this resource. As consequence
you also loose the console multiplexer. Therefore this
patch only calls hide-splash if there is only one active
tty such that we can be sure the user has a chance to
interact with dialogs.