### PR TITLE
Use setctsid/bash instead of sulogin for debugging

### DIFF
--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -335,7 +335,7 @@ function systemException {
             Echo "ssh root@${IPADDR}"
         fi
         echo reset > /root/.bashrc
-        sulogin -e -p $ttydev
+        sulogin --force --login-shell $ttydev
     ;;
     "user_reboot")
         Echo "reboot triggered by user"
@@ -5626,7 +5626,11 @@ function startShell {
             return
         fi
         Echo "Starting boot shell on $ELOG_BOOTSHELL"
-        setctsid -f $ELOG_BOOTSHELL /bin/bash
+        if lookup setctsid &>/dev/null;then
+            setctsid -f $ELOG_BOOTSHELL /bin/bash
+        else
+            sulogin --force --login-shell $ELOG_BOOTSHELL &
+        fi
         sleep 2
         ELOGSHELL_PID=$(fuser $ELOG_BOOTSHELL | tr -d " ")
         echo ELOGSHELL_PID=$ELOGSHELL_PID >> /iprocs

--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -5626,7 +5626,7 @@ function startShell {
             return
         fi
         Echo "Starting boot shell on $ELOG_BOOTSHELL"
-        sulogin -e -p $ELOG_BOOTSHELL &
+        setctsid -f $ELOG_BOOTSHELL /bin/bash
         sleep 2
         ELOGSHELL_PID=$(fuser $ELOG_BOOTSHELL | tr -d " ")
         echo ELOGSHELL_PID=$ELOGSHELL_PID >> /iprocs


### PR DESCRIPTION
The custom kiwi boot descriptions supports a boot process
accompanying debug shell if the kiwidebug=1 option is
set on the kernel command line. That shell was invoked
using sulogin. Problem is that this call occupies the
controlling terminal and console such that the typical
multiplexing of consoles through plymouth is stopped.
This means it's not possible to run e.g an oem deployment
with several active/multiplexed consoles and a backgrounding
debuging shell. This patch moves away from sulogin and
calls a bash through setctsid on a free console