### PR TITLE
centos: Use the correct grub2-efi and shim package names

### DIFF
--- a/centos/x86_64/centos-07.0-JeOS/config.xml
+++ b/centos/x86_64/centos-07.0-JeOS/config.xml
@@ -62,8 +62,8 @@
         <package name="basesystem"/>
         <package name="yum-plugin-priorities"/>
         <package name="nextgen-yum4"/>
-        <package name="grub2-efi-modules"/>
-        <package name="grub2-efi"/>
-        <package name="shim" arch="x86_64"/>
+        <package name="grub2-efi-x64-modules"/>
+        <package name="grub2-efi-x64"/>
+        <package name="shim-x64" arch="x86_64"/>
     </packages>
 </image>


### PR DESCRIPTION
CentOS has inherited the grub2-efi and shim package name changes
from Fedora, so we need to adapt for that.