### PR TITLE
allow disabling multipath

### DIFF
--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -9688,6 +9688,15 @@ function startMultipathd {
     local multipath_config=/etc/multipath.conf
     local wwid_timeout=3
     #======================================
+    # check if disabled on cmdline
+    #
+    if cat /proc/cmdline | grep -qi "multipath=off";then
+        return 0
+    fi
+    if cat /proc/cmdline | grep -qi "nompath";then
+        return 0
+    fi
+    #======================================
     # check already running
     #--------------------------------------
     if pidof multipathd &>/dev/null; then


### PR DESCRIPTION
custom_boot/functions.sh: allow disabling multipath
on the kernel cmdline (like in udev and multipath.service)