### PR TITLE
Update suse Factory/TW plymouth theme setup

### DIFF
--- a/suse/x86_64/suse-tumbleweed-JeOS/config.xml
+++ b/suse/x86_64/suse-tumbleweed-JeOS/config.xml
@@ -17,7 +17,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <users>
@@ -31,7 +31,7 @@
     </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>
-        <package name="plymouth-branding-openSUSE"/>
+        <package name="plymouth-theme-bgrt"/>
         <package name="plymouth-dracut"/>
         <package name="grub2-branding-openSUSE"/>
         <package name="ifplugd"/>


### PR DESCRIPTION
The way plymouth themes are provided has changed on suse.
The package plymouth-branding-openSUSE is no longer providing
the theme named openSUSE. In fact the plan is to switch to
the upstream bgrt theme which is provided in another package.
This commit adapts to the changes in the distribution.
This Fixes #40