### PR TITLE
Requires checkmedia for kiwi-image-iso-requires

### DIFF
--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -155,6 +155,7 @@ for the build host to build docker images
 Summary:        KIWI - buildservice host requirements for iso images
 Group:          System/Management
 Provides:       kiwi-image:iso
+Requires:       checkmedia
 Requires:       dosfstools
 Requires:       jing
 %if 0%{suse_version} >= 1500


### PR DESCRIPTION
Since https://github.com/SUSE/kiwi/pull/1094 mediacheck can be performed on non-x86 but `checkmedia` is not installed by default.

