### PR TITLE
Use default values for nr_inode on devtmpfs mounts

### DIFF
--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -403,11 +403,11 @@ function createInitialDevices {
     #======================================
     # mount devtmpfs or tmpfs
     #--------------------------------------
-    if mount -t devtmpfs -o mode=0755,nr_inodes=0 devtmpfs $prefix; then
+    if mount -t devtmpfs -o mode=0755 devtmpfs $prefix; then
         export have_devtmpfs=true
     else
         export have_devtmpfs=false
-        mount -t tmpfs -o mode=0755,nr_inodes=0 udev $prefix
+        mount -t tmpfs -o mode=0755 udev $prefix
         mknod -m 0666 $prefix/tty     c 5 0
         mknod -m 0600 $prefix/console c 5 1
         mknod -m 0666 $prefix/ptmx    c 5 2


### PR DESCRIPTION
Using nr_inode=0 is causing mount failures in recent kernels. This
option was introduced to fix issues in split systems, which are no
longer supported. According to that we just remove this option and
let mount set the default value, which depends on available memory
of the system.

Fixes SUSE/kiwi#1105