### PR TITLE
Fix spec for SLE 15 SP1

### DIFF
--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -78,11 +78,6 @@
 %define distro suse-tumbleweed
 %endif
 
-# SLES with sles_version macro
-%if 0%{?sles_version}
-%define distro suse-SLES%{sles_version}
-%endif
-
 # RHEL // CentOS
 # use the rhel templates for CentOS, too
 %if 0%{?rhel} == 7

--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -33,7 +33,7 @@
 %endif
 
 # SLE15:
-%if 0%{?sle_version} == 150000 && !0%{?is_opensuse}
+%if 0%{?suse_version} == 1500 && !0%{?is_opensuse}
 %define distro suse-SLES15
 %endif
 


### PR DESCRIPTION
The current package doesn't build on SLE 15 SP1 because the macro `%distro` is not set. This is caused by the check `%if 0%{?sle_version} == 150000` which doesn't evaluate to true on SLE 15 SP1 as `%sle_version` is 150100 there. This is fixed by using the macro `%suse_version` instead.

Builds on SLE 15 SP1: https://build.opensuse.org/package/show/home:dancermak:branches:Virtualization:Appliances:Builder/kiwi-boot-descriptions