### PR TITLE
Make application ID check in searchImageISODevice() case-insensitive

### DIFF
--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -2748,7 +2748,7 @@ function searchImageISODevice {
                 $isoinfo -d -i $i 2>/dev/null|grep "Application id:"|cut -f2 -d:
             )
             mbrVID=$(echo $mbrVID)
-            if [ "$mbrVID" = "$mbrIID" ];then
+            if [ "${mbrVID^^}" = "${mbrIID^^}" ];then
                 # /.../
                 # found ISO header on a device, now check if there is
                 # also a partition for this device with the same
@@ -2763,7 +2763,7 @@ function searchImageISODevice {
                             grep "Application id:"|cut -f2 -d:
                         )
                         mbrVID=$(echo $mbrVID)
-                        if [ "$mbrVID" = "$mbrIID" ];then
+                        if [ "${mbrVID^^}" = "${mbrIID^^}" ];then
                             biosBootDevice=$pdev
                             echo; return 0
                         fi


### PR DESCRIPTION
In function searchImageISODevice(), the application ID is read into variable mbrVID from output of "isoinfo" program. This application ID is a hexadecimal number generated earlier (in installBootLoader() function), and written to /boot/mbrid.

The problem is that the string written into /boot/mbrid contains lower-case letters, whereas isoinfo prints it out with upper-case letters. (e.g. "0x9339d2c2" versus "0X9339D2C2") Since the comparison in searchImageISODevice() is a simple string equality check, it obviously fails.

One solution is to make the check case-insensitive. This pull request achieves this by using a bash variable mangling feature present only in bash4 ("${variable^^}" to upper-case it). Since the functions.sh file is used in all the descriptions within custom_boot dir, it must be ensured that all of them use bash4. I do not have the time&resources to make this check, I am primarily interested in suse-SLES12 and suse-SLES15 descriptions, which both do use bash4.

If bash3 compatibility is necessary, and alternative would be something like:
upper_mbrVID=$(echo $mbrVID | tr a-z A-Z)
upper_mbrIID=$(echo $mbrIID | tr a-z A-Z)
...and comparing these two as strings.