### PR TITLE
Fix order of options on tar call

### DIFF
--- a/custom_boot/arch/x86_64/oemboot/dump
+++ b/custom_boot/arch/x86_64/oemboot/dump
@@ -855,11 +855,12 @@ function OEMInstall {
             test -e /usr/bin/mst || cp /usr/bin/tail /usr/bin/mst
             (
                 touch recovery.tar.gz
-                tar --numeric-owner -czpf recovery.tar.gz . \
+                tar --numeric-owner \
                     --exclude "./dev" \
                     --exclude "./proc" \
                     --exclude "./sys" \
-                    --exclude "./recovery.*" &
+                    --exclude "./recovery.*" \
+                    -czpf recovery.tar.gz . &
                 rPID=$!
                 while kill -0 $rPID &>/dev/null;do
                     rReady=$(stat --format="%s" ./recovery.tar.gz)

--- a/custom_boot/arch/x86_64/oemboot/repart
+++ b/custom_boot/arch/x86_64/oemboot/repart
@@ -710,11 +710,12 @@ function OEMRepart {
         else
             pushd /reco-root
             Echo "Creating recovery root tarball..."
-            tar --numeric-owner -czpf /reco-save/recovery.tar.gz . \
+            tar --numeric-owner \
                 --exclude "./dev" \
                 --exclude "./proc" \
                 --exclude "./sys" \
-                --exclude "./recovery.*"
+                --exclude "./recovery.*" \
+                -czpf /reco-save/recovery.tar.gz .
             popd
         fi
         mkdir /reco-save/boot


### PR DESCRIPTION
tar mandatory and optional options are positional and require
a certain order. If the order is wrong tar ignores options and
reports that. This patch brings all option in line with the
ordering requirement. This Fixes #1166