### PR TITLE
Fixed ISO Application ID match

### DIFF
--- a/custom_boot/functions.sh
+++ b/custom_boot/functions.sh
@@ -2745,7 +2745,7 @@ function searchImageISODevice {
                 continue
             fi
             mbrVID=$(
-                $isoinfo -d -i $i 2>/dev/null|grep "Application id:"|cut -f2 -d:
+                $isoinfo -d -i $i 2>/dev/null|grep "Application id:"|cut -f2 -d:|tr [:upper:] [:lower:]
             )
             mbrVID=$(echo $mbrVID)
             if [ "${mbrVID^^}" = "${mbrIID^^}" ];then


### PR DESCRIPTION
When creating ISO's with xorriso the application ID is stored
upper case. The match in this code did not care for this and
failed the match.