### PR TITLE
remove ifplugd from tumbleweed installation

### DIFF
--- a/custom_boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
+++ b/custom_boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
@@ -133,7 +133,6 @@
         <package name="fbiterm"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
-        <package name="ifplugd"/>
         <package name="iproute2"/>
         <package name="iputils"/>
         <package name="kbd"/>

--- a/custom_boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/custom_boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -167,7 +167,6 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
-        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/suse/armv7l/suse-tumbleweed-panda-JeOS/config.xml
+++ b/suse/armv7l/suse-tumbleweed-panda-JeOS/config.xml
@@ -53,7 +53,6 @@
         <package name="gpg2"/>
         <package name="grub2"/>
         <package name="grub2-arm-efi"/>
-        <package name="ifplugd"/>
         <package name="insserv-compat"/>
         <package name="iproute2"/>
         <package name="iputils"/>

--- a/suse/x86_64/suse-tumbleweed-JeOS/config.xml
+++ b/suse/x86_64/suse-tumbleweed-JeOS/config.xml
@@ -34,7 +34,6 @@
         <package name="plymouth-theme-bgrt"/>
         <package name="plymouth-dracut"/>
         <package name="grub2-branding-openSUSE"/>
-        <package name="ifplugd"/>
         <package name="iputils"/>
         <package name="vim"/>
         <package name="grub2"/>


### PR DESCRIPTION
ifplugd should get dropped from Factory/Tumbleweed, the code no longer
needs it since quite some time, so drop it from all tumbleweed configs.

See https://bugzilla.opensuse.org/show_bug.cgi?id=1160269