### PR TITLE
Added kiwi-image:wsl Provides

### DIFF
--- a/custom_boot/package/kiwi-boot-descriptions.spec
+++ b/custom_boot/package/kiwi-boot-descriptions.spec
@@ -136,6 +136,16 @@ order to have them in the buildservice created repositories to allow
 kiwi to build the custom boot image.
 %endif
 
+%package -n kiwi-image-wsl-requires
+Summary:        KIWI - buildservice host requirements for wsl images
+Group:          System/Management
+Provides:       kiwi-image:wsl
+Requires:       fb-util-for-appx
+
+%description -n kiwi-image-wsl-requires
+Meta package for the buildservice to pull in all required packages
+for the build host to build wsl/appx images
+
 %package -n kiwi-image-docker-requires
 Summary:        KIWI - buildservice host requirements for docker images
 Group:          System/Management
@@ -258,6 +268,9 @@ make buildroot=%{buildroot} install
 %files -n kiwi-boot-requires
 %defattr(-, root, root)
 %endif
+
+%files -n kiwi-image-wsl-requires
+%defattr(-, root, root)
 
 %files -n kiwi-image-docker-requires
 %defattr(-, root, root)


### PR DESCRIPTION
For support of the wsl/appx container format a new image
type will be provided. The tool to create that image type
is packaged in fb-util-for-appx. To allow the buildservice
to build this image type the obs worker has to install
this tool. This commit creates a sub-package for use with
the buildservice that manages all needed packages within
the new kiwi-image:wsl provides tag. This is related to
https://github.com/OSInside/kiwi/issues/1235