### PR TITLE
gawk in tw-bootstrap

### DIFF
--- a/suse/x86_64/suse-tumbleweed-JeOS/config.xml
+++ b/suse/x86_64/suse-tumbleweed-JeOS/config.xml
@@ -61,6 +61,7 @@
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>
+        <package name="gawk"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>
         <package name="ca-certificates"/>


### PR DESCRIPTION
added gawk to bootstrap base as kernel-default wants gawk and
wihtout explicit dependency busybox gawk would be added, which
breaks kernel default