### PR TITLE
Use busybox-coreutils in favor of coreutils

### DIFF
--- a/suse/x86_64/suse-tumbleweed-docker/config.xml
+++ b/suse/x86_64/suse-tumbleweed-docker/config.xml
@@ -24,7 +24,6 @@
   <packages type="image">
     <package name="ca-certificates"/>
     <package name="ca-certificates-mozilla"/>
-    <package name="coreutils"/>
     <package name="iputils"/>
     <package name="openSUSE-build-key"/>
     <package name="krb5"/>
@@ -37,5 +36,6 @@
     <package name="filesystem"/>
     <package name="openSUSE-release"/>
     <package name="shadow"/>
+    <package name="busybox-coreutils"/>
   </packages>
 </image>


### PR DESCRIPTION
The building of Tumbleweed docker images was broken for about 1 to 1,5 months due to installation conflicts with coreutils.

Replacing coreutils with busybox-coreutils and moving it to the bootstrap section lets the image build again.