### PR TITLE
adding grep and gzip as explicit dependences

### DIFF
--- a/suse/x86_64/suse-leap-15.2-JeOS/root/etc/motd
+++ b/suse/x86_64/suse-leap-15.2-JeOS/root/etc/motd
@@ -1,4 +1,4 @@
-This is the Leap 15.1 JeOS SuSE Linux System.
+This is the Leap 15.2 JeOS SuSE Linux System.
 To upgrade your system call:
 
         zypper refresh

--- a/suse/x86_64/suse-tumbleweed-JeOS/config.xml
+++ b/suse/x86_64/suse-tumbleweed-JeOS/config.xml
@@ -62,6 +62,8 @@
         <package name="udev"/>
         <package name="filesystem"/>
         <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>
         <package name="ca-certificates"/>


### PR DESCRIPTION
This avoids the installtion of their busybox variants,
which conflict with plymouth and make so the image not
buildable.