### PR TITLE
added explicit xz package so that busybox-xz is not installed

### DIFF
--- a/suse/x86_64/suse-tumbleweed/config.xml
+++ b/suse/x86_64/suse-tumbleweed/config.xml
@@ -74,5 +74,6 @@
         <package name="cracklib-dict-full"/>
         <package name="ca-certificates"/>
         <package name="openSUSE-release"/>
+        <package name="xz" />
     </packages>
 </image>


### PR DESCRIPTION
The packages dracut-kiwi-oem-repart and dracut-kiwi-oem-dump conflict with busybox-xz, which is installed in the bootstrap image, when xz is not explicitly installed.