### PR TITLE
ubuntu-jammy: fix a couple of idempotency issues

### DIFF
--- a/ubuntu/x86_64/ubuntu-jammy/config.sh
+++ b/ubuntu/x86_64/ubuntu-jammy/config.sh
@@ -60,5 +60,5 @@ baseSetRunlevel 3
 # Clear apt-get data
 #--------------------------------------
 apt-get clean
-rm -r /var/lib/apt/*
-rm -r /var/cache/apt/*
+rm -rf /var/lib/apt/*
+rm -rf /var/cache/apt/*

--- a/ubuntu/x86_64/ubuntu-jammy/config.sh
+++ b/ubuntu/x86_64/ubuntu-jammy/config.sh
@@ -31,7 +31,7 @@ echo "FONT_UNIMAP=" >> /etc/vconsole.conf
 #=======================================
 # Setup system timezone
 #---------------------------------------
-[ -f /etc/localtime ] && rm /etc/localtime
+[ -e /etc/localtime ] && rm /etc/localtime
 ln -s /usr/share/zoneinfo/${kiwi_timezone} /etc/localtime
 
 #=======================================


### PR DESCRIPTION
I'm not 100% if these changes are required, or if I'm using Kiwi in the wrong way as I experiment with it.

We'd like to build multiple images: M different image contents (e.g. database host, web server) built into (up to) N different image types (bare metal, virt guest, Docker). All of our M images share a common base, which we would like to prepare once. I'm currently experimenting with using `system prepare` multiple times with `--allow-existing-root` to do this (I've added a single package installation to `database` and `web` profiles within the jammy description to prove this out):

```
kiwi-ng system prepare --description kiwi-descriptions/ubuntu/x86_64/ubuntu-jammy --root build
cp -a build build.database
kiwi-ng --profile database system prepare --description kiwi-descriptions/ubuntu/x86_64/ubuntu-jammy --root build.database --allow-existing-root
cp -a build build.web
kiwi-ng --profile web system prepare --description kiwi-descriptions/ubuntu/x86_64/ubuntu-jammy --root build.web --allow-existing-root
```

With the fixes in this PR, this works! I get three separate roots with the appropriate packages, which I can then execute `create` against for each of the required image types. Is this a reasonable approach to achieve what I'm looking to do, or is there an alternative path which might make more sense? Thanks!

(The fixes here are required because `/etc/localtime` has already been linked by the first `prepare`, and `/var/*/apt` has already been cleaned by it.)