### PR TITLE
Help dracut to find its live rootfs

### DIFF
--- a/almalinux/x86_64/almalinux-8.x/config.xml
+++ b/almalinux/x86_64/almalinux-8.x/config.xml
@@ -63,6 +63,9 @@
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
+    <packages type="iso">
+        <package name="dracut-live"/>
+    </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="basesystem"/>


### PR DESCRIPTION
Otherwise dracut doesn't know how to handle `root=live:...` parameter.